### PR TITLE
Use var for compatibility with Android 4.x

### DIFF
--- a/www/LocalStorageHandle.js
+++ b/www/LocalStorageHandle.js
@@ -31,13 +31,13 @@ function LocalStorageHandle(success, error, intent, operation, args) {
         } catch (err) {
             error(new NativeStorageError(NativeStorageError.JSON_ERROR, "JS", err));
         }
-    } else if(operation === 'keys') {
-      const keys = [];
-      let key = localStorage.key(0);
+    } else if (operation === 'keys') {
+      var keys = [];
+      var key = localStorage.key(0);
       if(!key) {
         return success(keys);
       }
-      let i = 0;
+      var i = 0;
       while(key) {
         keys.push(key);
         i++;


### PR DESCRIPTION
Hi!

Thanks for a great plugin! I just got a couple of user reports that our app started crashing on Android 4.3 and traced the error to the use of let in the JS code for this plugin. It seems that support for let and const was introduced in Android 5. While the user share for Android 4.x is declining there are still a lot of phones out there that cannot be upgraded further than that.

Would you consider reverting to using plain "var" as in this pull request?

All the best!
Johan