### PR TITLE
Uniformity of `storageHandlerDelegate` call

### DIFF
--- a/www/mainHandle.js
+++ b/www/mainHandle.js
@@ -394,7 +394,7 @@ StorageHandle.prototype.getSecretItem = function(reference, encryptConfig, succe
 
 /* list keys */
 StorageHandle.prototype.keys = function(success, error) {
-  this.storageHandlerDelegate(success, error, "NativeStorage", "keys");
+  this.storageHandlerDelegate(success, error, "NativeStorage", "keys", []);
 };
 
 


### PR DESCRIPTION
Reference: Add keys function to list storage keys PR #61 

The delegate had to be called, but one param was missing.
