### PR TITLE
Make NativeStorageError a real Error, you can test with  - fixes #83

### DIFF
--- a/www/NativeStorageError.js
+++ b/www/NativeStorageError.js
@@ -8,6 +8,11 @@ var NativeStorageError = function(code, source, exception) {
     this.exception = exception || null;
 };
 
+// Make NativeStorageError a real Error, you can test with `instanceof Error`
+NativeStorageError.prototype = Object.create(Error.prototype, {
+  constructor: { value: NativeStorageError }
+});
+
 NativeStorageError.NATIVE_WRITE_FAILED = 1;
 NativeStorageError.ITEM_NOT_FOUND = 2;
 NativeStorageError.NULL_REFERENCE = 3;


### PR DESCRIPTION
This PR means that you can now check if the callback argument is a NativeStorageError with `instanceof`.

E.g. `if( e instanceof Error ) ...`

My use-case is that I need to test if the argument to the callbacks is a NativeStorageError.

```js
function readFile(fileName, callback) {
  fileSystem.getItem(
    fileName,
    normalizeCallback(callback, fileName, actionEnum.read), // success
    normalizeCallback(callback, fileName, actionEnum.read)) // failure
}

function normalizeCallback(callback, fileName, action) {
  return function(e) {
    var err
    if(e instanceof Error) {
      err = {
        name: fileName,
        action: getName(actionEnum, action),
        toString: function toString() { return getName(errorEnum, e.code) }
      }
      callback(err, null)
    } else {
      callback(null, fileFactory(fileName, e == null ? '' : e.data))
    }
  }
}
```