### PR TITLE
Fix browser keys method using .length

### DIFF
--- a/www/LocalStorageHandle.js
+++ b/www/LocalStorageHandle.js
@@ -33,15 +33,8 @@ function LocalStorageHandle(success, error, intent, operation, args) {
         }
     } else if (operation === 'keys') {
       var keys = [];
-      var key = localStorage.key(0);
-      if(!key) {
-        return success(keys);
-      }
-      var i = 0;
-      while(key) {
-        keys.push(key);
-        i++;
-        key = localStorage.key(i);
+      for(var i = 0; i < localStorage.length; i++){
+         keys.push(localStorage.key(i));
       }
       success(keys);
     }


### PR DESCRIPTION
This is the way they are doing it on the [mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/Storage/key)  

Also, there is a (twisted) possible bug with the current approach:  '' is a valid key in localstorage, which will break the while loop, not returning every keys.

Cheers