### PR TITLE
Allow the shared preferences name to be defined in cordova's config.xml file

### DIFF
--- a/src/android/NativeStorage.java
+++ b/src/android/NativeStorage.java
@@ -25,7 +25,6 @@ import android.app.Activity;
 
 public class NativeStorage extends CordovaPlugin {
     public static final String TAG = "Native Storage";
-    public static final String PREFS_NAME = "NativeStorage";
     private SharedPreferences sharedPref;
     private SharedPreferences.Editor editor;
 
@@ -36,6 +35,7 @@ public class NativeStorage extends CordovaPlugin {
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
         Log.v(TAG, "Init NativeStorage");
+        String PREFS_NAME = preferences.getString("NativeStorageSharedPreferencesName", "NativeStorage");
         sharedPref = cordova.getActivity().getSharedPreferences(PREFS_NAME, Activity.MODE_PRIVATE);
         editor = sharedPref.edit();
     }


### PR DESCRIPTION
This PR allows for the android shared preference name to be defined in cordova's config.xml file as a preference tag, i.e.:

`<preference name="NativeStorageSharedPreferencesName" value="myPrefs" />` 

This allows for situations where the user needs control over what the shared preferences is called (i.e. updating a legacy app).