### PR TITLE
Fix iOS setItem

### DIFF
--- a/src/ios/NativeStorage.m
+++ b/src/ios/NativeStorage.m
@@ -211,11 +211,7 @@
 		NSString* reference = [command.arguments objectAtIndex:0];
 		NSString* aString = [command.arguments objectAtIndex:1];
 
-		if(reference==nil)
-		{
-			pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsString:@"Reference was null"];
-		}
-		else if([aString class] == [NSNull class])
+		if(reference==nil || [aString class] == [NSNull class])
 		{
 			pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsInt:3];
 		}

--- a/src/ios/NativeStorage.m
+++ b/src/ios/NativeStorage.m
@@ -211,19 +211,23 @@
 		NSString* reference = [command.arguments objectAtIndex:0];
 		NSString* aString = [command.arguments objectAtIndex:1];
 
-		if(reference!=nil && [aString class] == [NSNull class])
+		if(reference==nil)
+		{
+			pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsString:@"Reference was null"];
+		}
+		else if([aString class] == [NSNull class])
+		{
+			pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsInt:3];
+		}
+		else
 		{
 			NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 			[defaults setObject: aString forKey:reference];
 			BOOL success = [defaults synchronize];
 			if(success) pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK messageAsString:aString];
 			else pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsInt:1]; //Write has failed
+		}
 
-		}
-		else
-		{
-			pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsInt:3]; //Reference was null
-		}
 		[self.commandDelegate sendPluginResult:pluginResult callbackId: command.callbackId];
 	}];
 }


### PR DESCRIPTION
Fixes #112

Corrects the null reference check for items being set.

~~Also separates the error messages to make it clearer what is null (key or value).~~
Retains the original behaviour of returning an error with int code `3` when either key or value is null. 