### PR TITLE
fix: JSON.stringify of string was adding add additional quotes

### DIFF
--- a/www/mainHandle.js
+++ b/www/mainHandle.js
@@ -359,7 +359,11 @@ StorageHandle.prototype.setItem = function(reference, obj, success, error) {
 
   var objAsString = "";
   try {
-    objAsString = JSON.stringify(obj);
+    if (typeof obj === 'string') {
+      objAsString = obj;
+    } else {
+      objAsString = JSON.stringify(obj);
+    }
   } catch (err) {
     error(new NativeStorageError(NativeStorageError.JSON_ERROR, "JS", err));
     return;


### PR DESCRIPTION
Currently `setItem(key, "stringValue")` will store the value `"\"stringValue\""` into `key`.

This commit avoids `JSON.stringify` if value is of type `string`. 

Since this is a generic method, that is expected to support all value type and is the only setter method supported in [@ionic-native](https://github.com/ionic-team/ionic-native/blob/master/src/@ionic-native/plugins/native-storage/index.ts), this commit helps in storing string values.