### PR TITLE
Fix success callback not being called for initWithSuiteName

### DIFF
--- a/src/ios/NativeStorage.m
+++ b/src/ios/NativeStorage.m
@@ -18,6 +18,7 @@
         {
             _suiteName = aSuiteName;
             _appGroupUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:_suiteName];
+            pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK];
         }
         else
         {


### PR DESCRIPTION
Currently, if a call to `initWithSuiteName` is successful, the success callback is not currently called. This PR fixes this issue.