### PR TITLE
Bugfix to add pluginResult for initWithSuiteName success

### DIFF
--- a/src/ios/NativeStorage.m
+++ b/src/ios/NativeStorage.m
@@ -18,6 +18,7 @@
         {
             _suiteName = aSuiteName;
             _appGroupUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:_suiteName];
+	    pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK];
         }
         else
         {


### PR DESCRIPTION
Originally the return value is nil on success